### PR TITLE
ci: npm publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: vm-sdk-unit-tests
+name: CI
 
 on:
   push:
@@ -7,17 +7,24 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
-  Jest:
+  test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          node-version: '22'
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
           cache: 'npm'
-      - name: Run Tests
-        run: |
-          npm install
-          npm test
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Build package
+        run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'TosiDrop/vm-sdk'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify release tag
+        run: npm run release:check -- "$GITHUB_REF_NAME"
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+
+      - name: Inspect package contents
+        run: npm pack --dry-run
+
+      - name: Check npm version availability
+        run: |
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="$(node -p "require('./package.json').version")"
+
+          if npm view "$package_name@$package_version" version >/tmp/npm-version.txt 2>/tmp/npm-view-error.txt; then
+            echo "::error::$package_name@$package_version already exists on npm."
+            exit 1
+          fi
+
+          if ! grep -q 'E404' /tmp/npm-view-error.txt; then
+            cat /tmp/npm-view-error.txt
+            exit 1
+          fi
+
+      - name: Publish package
+        run: npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # vm-sdk
 VendingMachine JavaScript SDK
+
+## Publishing
+
+Publishing is handled by `.github/workflows/publish.yml` when a tag matching
+`vX.Y.Z` is pushed. The workflow validates that the tag exactly matches
+`package.json`, installs with `npm ci`, runs tests, builds the package, inspects
+the npm tarball, checks that the version is not already published, and then
+publishes to npm using trusted publishing/OIDC (no `NPM_TOKEN` secret required).
+
+### One-time setup before the first release
+
+**1. Configure npm trusted publishing** on the [vm-sdk npm package settings](https://www.npmjs.com/package/vm-sdk):
+
+- Provider: GitHub Actions
+- Organization/user: `TosiDrop`
+- Repository: `vm-sdk`
+- Workflow filename: `publish.yml`
+
+**2. Harden the npm package** (Publish Access settings on npmjs.com):
+
+- Require 2FA for publishing
+- Disallow legacy token publishing (automation tokens cannot publish)
+
+**3. Protect release tags** in GitHub repository settings → Rules → New ruleset:
+
+- Target: tags matching `v*.*.*`
+- Require linear history / restrict deletions so tags cannot be overwritten or removed after release
+
+### Release flow
+
+```sh
+# Bump version in package.json and create a signed tag
+npm version 1.2.3
+git push origin main --follow-tags
+```
+
+The `v1.2.3` tag triggers the publish workflow automatically.
+GitHub Actions uses OIDC to obtain a temporary npm token — no stored secret needed.

--- a/package.json
+++ b/package.json
@@ -1,16 +1,25 @@
 {
   "name": "vm-sdk",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "description": "A JavaScript/TypeScript SDK for interacting with the VM API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
     "dist",
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "clean": "node scripts/clean-dist.mjs",
+    "build": "npm run clean && tsc",
+    "prepack": "npm run build",
+    "release:check": "node scripts/validate-release-tag.mjs",
     "watch": "tsc --watch",
     "test": "jest",
     "lint": "eslint 'src/**/*.{ts,tsx}'"
@@ -18,6 +27,13 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/TosiDrop/vm-sdk"
+  },
+  "homepage": "https://github.com/TosiDrop/vm-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/TosiDrop/vm-sdk/issues"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "sdk",

--- a/scripts/clean-dist.mjs
+++ b/scripts/clean-dist.mjs
@@ -1,0 +1,3 @@
+import { rmSync } from 'node:fs';
+
+rmSync(new URL('../dist', import.meta.url), { recursive: true, force: true });

--- a/scripts/validate-release-tag.mjs
+++ b/scripts/validate-release-tag.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+
+const tag = process.argv[2] ?? process.env.GITHUB_REF_NAME ?? '';
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+);
+
+const versionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const tagPattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+if (!tagPattern.test(tag)) {
+  fail(`Release tag "${tag}" must match vX.Y.Z, for example v1.2.3.`);
+}
+
+if (!versionPattern.test(packageJson.version)) {
+  fail(`package.json version "${packageJson.version}" must match X.Y.Z.`);
+}
+
+const expectedTag = `v${packageJson.version}`;
+
+if (tag !== expectedTag) {
+  fail(`Release tag "${tag}" does not match package.json version "${expectedTag}".`);
+}
+
+console.log(`Release tag ${tag} matches package.json version ${packageJson.version}.`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"],
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "homepage": "https://github.com/TosiDrop/vm-sdk"
+  "exclude": ["node_modules", "dist", "tests", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
Closes #40 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tag-driven npm publishing (on `vX.Y.Z`) with trusted publishing/OIDC, provenance, and pre-publish validation.
  * Updated the package’s public entry point using an `exports` map for more consistent resolution.
* **Bug Fixes**
  * Strengthened release-tag validation and added checks to avoid publishing an already-released version.
* **Documentation**
  * Documented the end-to-end release flow and one-time publishing setup in the README.
* **Chores**
  * Updated CI to run a cleaner flow (install, test, build) with tightened permissions; added dist cleanup and refined TypeScript exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->